### PR TITLE
fix: Upgrade parse-url@8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,13 @@
     "publish-version": "lerna publish from-package --yes --no-verify-access"
   },
   "devDependencies": {
+    "@backstage/cli": "^0.18.0",
+    "@types/react": "^17.0.0",
     "lerna": "^5.0.0",
     "react": "^17.0.0",
-    "react-dom": "^17.0.0",
-    "@types/react": "^17.0.0",
-    "@backstage/cli": "^0.18.0"
+    "react-dom": "^17.0.0"
+  },
+  "dependencies": {
+    "parse-url": "8.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13240,6 +13240,13 @@ parse-path@^7.0.0:
   dependencies:
     protocols "^2.0.0"
 
+parse-url@8.1.0, parse-url@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-8.1.0.tgz#972e0827ed4b57fc85f0ea6b0d839f0d8a57a57d"
+  integrity sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==
+  dependencies:
+    parse-path "^7.0.0"
+
 parse-url@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-7.0.2.tgz#d21232417199b8d371c6aec0cedf1406fd6393f0"
@@ -13249,13 +13256,6 @@ parse-url@^7.0.2:
     normalize-url "^6.1.0"
     parse-path "^5.0.0"
     protocols "^2.0.1"
-
-parse-url@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-8.1.0.tgz#972e0827ed4b57fc85f0ea6b0d839f0d8a57a57d"
-  integrity sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==
-  dependencies:
-    parse-path "^7.0.0"
 
 parse5@6.0.1:
   version "6.0.1"


### PR DESCRIPTION
High severity issue.

- Fix: Update the version of the parse-url dependency to v8.1.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
